### PR TITLE
Write specs mk include file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -86,5 +86,20 @@
     "bpmn/test-cases/start-timer1/start-timer1.bpmn": [
       "Process_84evfap"
     ]
+  },
+  "workflow_spec_json_by_process_id": {
+    "Process_048urbd": "specs/test-cases/call-activity-with-manual-tasks/call_manual_tasks.json",
+    "Process_84evfap": "specs/test-cases/start-timer1/start-timer1.json",
+    "Process_90mmqlw": "specs/test-cases/multiple-call-activities/multiple_call_activities.json",
+    "Process_cqu23d1": "specs/test-cases/nested-call-activities/nested_call_activity.json",
+    "Process_diu8ta2": "specs/test-cases/manual-tasks/manual_tasks.json",
+    "Process_fwplcm1": "specs/test-cases/cycle-start-timer/cycle-start-timer.json",
+    "Process_p4pfxhq": "specs/test-cases/simple-call-activity/simple_call_activity.json",
+    "Process_sypm122": "specs/test-cases/countries-and-cities/country_cities.json",
+    "Process_vv0fdgv": "specs/test-cases/simple-subprocess/simple_subprocess.json",
+    "Process_w13g1wd": "specs/test-cases/madhu-timer/madhutimertask.json",
+    "SingleTask_Process": "specs/test-cases/single-task/single_task.json",
+    "coin-gecko_simple-price": "specs/test-cases/http-v2-connector-test/httpv2.json",
+    "no_tasks": "specs/test-cases/no-tasks/no-tasks.json"
   }
 }

--- a/specs.mk
+++ b/specs.mk
@@ -1,0 +1,13 @@
+SPECS_FILE_coin-gecko_simple-price := specs/test-cases/http-v2-connector-test/httpv2.json
+SPECS_FILE_Process_p4pfxhq := specs/test-cases/simple-call-activity/simple_call_activity.json
+SPECS_FILE_no_tasks := specs/test-cases/no-tasks/no-tasks.json
+SPECS_FILE_Process_w13g1wd := specs/test-cases/madhu-timer/madhutimertask.json
+SPECS_FILE_Process_sypm122 := specs/test-cases/countries-and-cities/country_cities.json
+SPECS_FILE_Process_90mmqlw := specs/test-cases/multiple-call-activities/multiple_call_activities.json
+SPECS_FILE_Process_vv0fdgv := specs/test-cases/simple-subprocess/simple_subprocess.json
+SPECS_FILE_Process_cqu23d1 := specs/test-cases/nested-call-activities/nested_call_activity.json
+SPECS_FILE_Process_84evfap := specs/test-cases/start-timer1/start-timer1.json
+SPECS_FILE_Process_fwplcm1 := specs/test-cases/cycle-start-timer/cycle-start-timer.json
+SPECS_FILE_Process_048urbd := specs/test-cases/call-activity-with-manual-tasks/call_manual_tasks.json
+SPECS_FILE_Process_diu8ta2 := specs/test-cases/manual-tasks/manual_tasks.json
+SPECS_FILE_SingleTask_Process := specs/test-cases/single-task/single_task.json


### PR DESCRIPTION
Generates `specs.mk` which can be included in calling application Makefiles to find the specs file for a given process id.

The calling application's Makefile could contain something like:

```
include	process-models/specs.mk

PROCESS_ID ?= no_tasks

SPECS_FILE := process-models/$(SPECS_FILE_$(PROCESS_ID))
```

Then process the specs file for the provided process id.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new mechanisms to enhance the generation of project manifests and support files.

- **Documentation**
  - Updated documentation to reflect the addition of new dictionary entries and functions.

- **Refactor**
  - Streamlined the process of generating specification files for better project organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->